### PR TITLE
fix deprecation warning on geolocationfield

### DIFF
--- a/django_google_maps/fields.py
+++ b/django_google_maps/fields.py
@@ -113,7 +113,7 @@ class GeoLocationField(models.CharField):
         kwargs['max_length'] = 100
         super(GeoLocationField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)
 
     def to_python(self, value):


### PR DESCRIPTION
Just want to fix this warning when running with django 2.2
```
RemovedInDjango30Warning: Remove the context parameter from GeoLocationField.from_db_value(). Support for it will be removed in Django 3.0.
```