### PR TITLE
Widget data attribute for AutocompleteOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ on the `AddressField` widget. The list of allowed values is: `hybrid`, `roadmap`
             'widget': map_widgets.GoogleMapsAddressWidget(attrs={'data-map-type': 'roadmap'})},
       }
   ```  
+  
+- To change the autcomplete options, you can add an html attribute
+on the `AddressField` widget. 
+See https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete for a list of available options
+
+  ```python
+  from django.contrib import admin
+  from django_google_maps import widgets as map_widgets
+  from django_google_maps import fields as map_fields
+  
+  class RentalAdmin(admin.ModelAdmin):
+      formfield_overrides = {
+          map_fields.AddressField: {
+            'widget': map_widgets.GoogleMapsAddressWidget(attrs={
+                'types': ['geocode', 'establishment'],
+                'componentRestrictions': {
+                    'country': 'us'
+                }
+            })},
+      }
+  ```  
 
 That should be all you need to get started.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ on the `AddressField` widget.
 See https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete for a list of available options
 
   ```python
+  import json
   from django.contrib import admin
   from django_google_maps import widgets as map_widgets
   from django_google_maps import fields as map_fields
@@ -73,11 +74,14 @@ See https://developers.google.com/maps/documentation/javascript/places-autocompl
       formfield_overrides = {
           map_fields.AddressField: {
             'widget': map_widgets.GoogleMapsAddressWidget(attrs={
-                'types': ['geocode', 'establishment'],
-                'componentRestrictions': {
-                    'country': 'us'
-                }
-            })},
+                'data-autocomplete-options': json.dumps({
+                    'types': ['geocode', 'establishment'],
+                    'componentRestrictions': {
+                        'country': 'us'
+                    }
+                })
+            })
+          },
       }
   ```  
 

--- a/django_google_maps/static/django_google_maps/js/google-maps-admin.js
+++ b/django_google_maps/static/django_google_maps/js/google-maps-admin.js
@@ -59,7 +59,7 @@ function googleMapAdmin() {
 
             autocomplete = new google.maps.places.Autocomplete(
                 /** @type {!HTMLInputElement} */(document.getElementById(addressId)),
-                {types: ['geocode']});
+                self.getAutoCompleteOptions());
 
             // this only triggers on enter, or if a suggested location is chosen
             // todo: if a user doesn't choose a suggestion and presses tab, the map doesn't update
@@ -86,6 +86,19 @@ function googleMapAdmin() {
             }
 
             return google.maps.MapTypeId.HYBRID;
+        },
+
+        getAutoCompleteOptions : function() {
+            var geolocation = document.getElementById(addressId);
+            var autocompleteOptions = geolocation.getAttribute('data-autocomplete-options');
+
+            if (!autocompleteOptions) {
+                return {
+                   types: ['geocode']
+                };
+            }
+
+            return JSON.parse(autocompleteOptions);
         },
 
         getExistingLocation: function() {


### PR DESCRIPTION
Added javascript code to read an addition data attribute for custom AutocompleteOptions.
Google maps reference
https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete

Updated english documentation as well