### PR TITLE
remove settings.STATIC_URL from widget

### DIFF
--- a/django_google_maps/widgets.py
+++ b/django_google_maps/widgets.py
@@ -8,12 +8,11 @@ class GoogleMapsAddressWidget(widgets.TextInput):
 
     class Media:
         css = {
-            'all': (settings.STATIC_URL +
-                    'django_google_maps/css/google-maps-admin.css', )
+            'all': ('django_google_maps/css/google-maps-admin.css', )
         }
         js = (
             'https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js',
             'https://maps.google.com/maps/api/js?key={}&libraries=places'.format(
                 settings.GOOGLE_MAPS_API_KEY),
-            settings.STATIC_URL + 'django_google_maps/js/google-maps-admin.js',
+            'django_google_maps/js/google-maps-admin.js',
         )


### PR DESCRIPTION
This change is to fix an issue I was having with [django-storages](https://github.com/jschneier/django-storages).  Django already looks up the path so `settings.STATIC_URL` is unnecessary.